### PR TITLE
fix unicode in path error

### DIFF
--- a/beetsplug/check.py
+++ b/beetsplug/check.py
@@ -156,7 +156,7 @@ class CheckPlugin(BeetsPlugin):
         if integrity_errors:
             log.warn(u'Warning: failed to verify integrity')
             for error in integrity_errors:
-                log.warn('  {}: {}'.format(displayable_path(item.path), error))
+                log.warn(u'  {}: {}'.format(displayable_path(item.path), error))
             if beets.config['import']['quiet'] \
                or input_yn(u'Do you want to skip this album (Y/n)'):
                 log.info(u'Skipping.')


### PR DESCRIPTION
  File "/usr/lib/python2.7/site-packages/beetsplug/check.py", line 159, in verify_import_integrity
    log.warn('  {}: {}'.format(displayable_path(item.path), error))
  File "/usr/lib/python2.7/logging/__init__.py", line 1172, in warning
    self._log(WARNING, msg, args, **kwargs)
  File "/usr/lib/python2.7/logging/__init__.py", line 1279, in _log
    self.handle(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 1288, in handle
    if (not self.disabled) and self.filter(record):
  File "/usr/lib/python2.7/logging/__init__.py", line 615, in filter
    if not f.filter(record):
  File "/home/shizeeg/workspace/beets/beets/plugins.py", line 61, in filter