### PR TITLE
Fix #22

### DIFF
--- a/beetsplug/check.py
+++ b/beetsplug/check.py
@@ -14,14 +14,13 @@
 import re
 import os
 import sys
-import logging
 from subprocess import Popen, PIPE, STDOUT, check_call
 from hashlib import sha256
 from optparse import OptionParser
 from concurrent import futures
 
 import beets
-from beets import importer, config
+from beets import importer, config, logging
 from beets.plugins import BeetsPlugin
 from beets.ui import Subcommand, decargs, colorize, input_yn, UserError
 from beets.library import ReadError


### PR DESCRIPTION
Use the logging facilities provided by beets to avoid polluting the global space and cause issues when running in threaded mode