### PR TITLE
Check if file is missing when running `beet check --add`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Upcoming
 
 - Drop support for Python2.7
 - Require `beets>=1.4.7`
+- Fix a crash in `beet check --add` when a music file is not found on disk. (@ssssam)
 
 v0.12.1 2020-04-19
 ------------------

--- a/beetsplug/check.py
+++ b/beetsplug/check.py
@@ -245,7 +245,13 @@ class CheckCommand(Subcommand):
             log.debug(
                 u'adding checksum for {0}'.format(displayable_path(item.path))
             )
-            set_checksum(item)
+            try:
+                set_checksum(item)
+            except FileNotFoundError as ex:
+                log.warning(u'{} {}: {}'.format(
+                    colorize('text_warning', u'WARNING'), 'No such file',
+                    displayable_path(item.path)))
+                return
             if self.check_integrity:
                 try:
                     verify_integrity(item)

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -48,6 +48,18 @@ class CheckAddTest(TestBase, TestCase):
         item.load()
         self.assertEqual(item['checksum'], orig_checksum)
 
+    def test_dont_fail_missing_file(self):
+        self.setupFixtureLibrary()
+        item = self.lib.items().get()
+        del item['checksum']
+        item.path = '/doesnotexist'
+        item.store()
+
+        with captureLog() as logs:
+            beets.ui._raw_main(['check', '-a'])
+
+        self.assertIn('WARNING No such file: /doesnotexist', '\n'.join(logs))
+
     def test_add_shows_integrity_warning(self):
         MockChecker.install()
         item = self.addIntegrityFailFixture(checksum=False)


### PR DESCRIPTION
Previously, missing files would cause the program to abort with
a FileNotFoundError. Now, they trigger a warning message and
the program continues.